### PR TITLE
Fix for APK gen exception: com.android.dex.DexException

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,13 +33,6 @@ android {
             }
         }
     }
-    dexOptions {
-        // This workaround exists to mitigate an error that can be encountered when
-        // generating a signed APK:
-        //   com.android.dex.DexException: Cannot merge new index 65536 into a non-jumbo instruction!
-        jumboMode = true
-    }
-    
     compileOptions {
         // This went in on 2019-05-25 because okhttp3-4.0.0-alpha01 contains Java 8 bytecode.
         // The error message for this kindly offered the alternative of setting minSdkVersion to 26,
@@ -48,6 +41,13 @@ android {
         sourceCompatibility 1.8
         targetCompatibility 1.8
     }
+    dexOptions {
+        // This workaround exists to mitigate an error that can be encountered when
+        // generating a signed APK:
+        //   com.android.dex.DexException: Cannot merge new index 65536 into a non-jumbo instruction!
+        jumboMode = true
+    }
+}
 
 buildscript {
     repositories {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,6 +33,12 @@ android {
             }
         }
     }
+    dexOptions {
+        // This workaround exists to mitigate an error that can be encountered when
+        // generating a signed APK:
+        //   com.android.dex.DexException: Cannot merge new index 65536 into a non-jumbo instruction!
+        jumboMode = true
+    }
 }
 
 buildscript {


### PR DESCRIPTION
Set dexOptions.jumboMode = true; to mitigate an exception that
might be encountered when trying to generate a (signed?) APK:
"com.android.dex.DexException: Cannot merge new index 65536 into a non-jumbo instruction!"

Solution was taken from this stack overflow article:
https://stackoverflow.com/questions/26093664/dexexception-cannot-merge-new-index-65536-into-a-non-jumbo-instruction